### PR TITLE
Makes the boosted overdrive value the correct one

### DIFF
--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -55,7 +55,7 @@ export default function Block({
         </tr>
         <tr>
           <td>od+phase</td>
-          <td>{(block.data.count / 2.125).toFixed(2)}</td>
+          <td>{(block.data.count / 2.25).toFixed(2)}</td>
         </tr>
         <tr>
           <td>power</td>


### PR DESCRIPTION
It's not a 2.125x boost, it's a 2.25x. See in game description, the [wikipage](https://mindustrygame.github.io/wiki/blocks/effect/overdrive-projector/) and the [source code](https://github.com/Anuken/Mindustry/blob/master/core/src/mindustry/world/blocks/defense/OverdriveProjector.java#L22) of the combination of the two variables

@vektah requesting speedmerge cause damn that's a bruh moment